### PR TITLE
The canvas will now redraw if styles change

### DIFF
--- a/docs/examples/clear_pixel.py
+++ b/docs/examples/clear_pixel.py
@@ -1,0 +1,23 @@
+from textual.app import App, ComposeResult
+from textual.color import Color
+
+from textual_canvas import Canvas
+
+
+class ClearPixelApp(App[None]):
+    CSS = """
+    Canvas {
+        background: $panel;
+        color: blue;
+    }
+    """
+
+    def compose(self) -> ComposeResult:
+        yield Canvas(30, 30, Color.parse("cornflowerblue"))
+
+    def on_mount(self) -> None:
+        self.query_one(Canvas).draw_line(10, 10, 15, 10).clear_pixel(12, 10)
+
+
+if __name__ == "__main__":
+    ClearPixelApp().run()

--- a/docs/examples/clear_pixels.py
+++ b/docs/examples/clear_pixels.py
@@ -1,0 +1,29 @@
+from textual.app import App, ComposeResult
+from textual.color import Color
+
+from textual_canvas import Canvas
+
+
+class ClearPixelsApp(App[None]):
+    CSS = """
+    Canvas {
+        background: $panel;
+        color: blue;
+    }
+    """
+
+    def compose(self) -> ComposeResult:
+        yield Canvas(30, 30, Color.parse("cornflowerblue"))
+
+    def on_mount(self) -> None:
+        self.query_one(Canvas).draw_line(10, 10, 16, 10).clear_pixels(
+            (
+                (11, 10),
+                (13, 10),
+                (15, 10),
+            )
+        )
+
+
+if __name__ == "__main__":
+    ClearPixelsApp().run()

--- a/docs/source/guide.md
+++ b/docs/source/guide.md
@@ -206,6 +206,22 @@ circle on the canvas. For example:
     --8<-- "docs/examples/draw_circle.py"
     ```
 
+### Clearing a pixel
+
+Use [`clear_pixel`][textual_canvas.Canvas.clear_pixel] to set a pixel's
+colour to the canvas' colour. For example:
+
+=== "Clearing a pixel"
+
+    ```{.textual path="docs/examples/clear_pixel.py"}
+    ```
+
+=== "clear_pixel.py"
+
+    ```python
+    --8<-- "docs/examples/clear_pixel.py"
+    ```
+
 ## Further help
 
 You can find more detailed documentation of the API [in the next

--- a/docs/source/guide.md
+++ b/docs/source/guide.md
@@ -55,10 +55,9 @@ style this with CSS just as you always would. But the canvas itself -- the
 area that you'll be drawing in inside the widget -- can have its own
 background colour.
 
-By default the canvas background colour will be set to the widget's
-background colour; but you can pass
-[`canvas_color`][textual_canvas.canvas.Canvas] as a parameter to change
-this.
+By default the canvas background colour will be the widget's background
+colour; but you can pass [`canvas_color`][textual_canvas.canvas.Canvas] as a
+parameter to change this.
 
 To illustrate, here is a `Canvas` widget where no background colour is
 specified, so the canvas background and the widget background are the same:
@@ -96,13 +95,6 @@ background colour when we create it:
 
     1. Note how `Canvas` is given its own background colour.
 
-!!! note
-
-    The defaulting of the canvas background to the widget's background is
-    something that only happens when the widget is mounted. If you style the
-    widget's background differently later on, the canvas' background **will
-    not change accordingly**.
-
 #### The pen colour
 
 The `Canvas` widget has a "pen" colour; any time a drawing operation is
@@ -110,13 +102,6 @@ performed, if no colour is given to the method, the "pen" colour is used. By
 default that colour is taken from the
 [`color`](https://textual.textualize.io/styles/color/) styling of the
 widget.
-
-!!! note
-
-    The defaulting of the pen colour to the widget's colour is
-    something that only happens when the widget is mounted. If you style the
-    widget's `color` differently later on, the canvas' pen colour **will
-    not change accordingly**.
 
 ## Drawing on the canvas
 

--- a/docs/source/guide.md
+++ b/docs/source/guide.md
@@ -206,12 +206,12 @@ circle on the canvas. For example:
     --8<-- "docs/examples/draw_circle.py"
     ```
 
-### Clearing a pixel
+### Clearing a single pixel
 
 Use [`clear_pixel`][textual_canvas.Canvas.clear_pixel] to set a pixel's
 colour to the canvas' colour. For example:
 
-=== "Clearing a pixel"
+=== "Clearing a single pixel"
 
     ```{.textual path="docs/examples/clear_pixel.py"}
     ```

--- a/docs/source/guide.md
+++ b/docs/source/guide.md
@@ -222,6 +222,22 @@ colour to the canvas' colour. For example:
     --8<-- "docs/examples/clear_pixel.py"
     ```
 
+### Clearing multiple pixels
+
+Use [`clear_pixels`][textual_canvas.Canvas.clear_pixels] to set the colour
+of multiple pixels to the canvas' colour. For example:
+
+=== "Clearing multiple pixels"
+
+    ```{.textual path="docs/examples/clear_pixels.py"}
+    ```
+
+=== "clear_pixels.py"
+
+    ```python
+    --8<-- "docs/examples/clear_pixels.py"
+    ```
+
 ## Further help
 
 You can find more detailed documentation of the API [in the next

--- a/src/textual_canvas/__main__.py
+++ b/src/textual_canvas/__main__.py
@@ -29,9 +29,9 @@ class CanvasTestApp(App[None]):
     """
 
     BINDINGS = [
-        ("r", "clear(255, 0, 0)"),
-        ("g", "clear(0, 255, 0)"),
-        ("b", "clear(0, 0, 255)"),
+        ("r", "canvas(255, 0, 0)"),
+        ("g", "canvas(0, 255, 0)"),
+        ("b", "canvas(0, 0, 255)"),
     ]
 
     def compose(self) -> ComposeResult:
@@ -61,10 +61,9 @@ class CanvasTestApp(App[None]):
 
         canvas.focus()
 
-    def action_clear(self, red: int, green: int, blue: int) -> None:
-        """Handle the clear keyboard action."""
-        self.query_one(Canvas).clear(Color(red, green, blue))
-        self.its_all_dark()
+    def action_canvas(self, red: int, green: int, blue: int) -> None:
+        """Change the canvas colour."""
+        self.query_one(Canvas).styles.background = Color(red, green, blue)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
As part of this, I've made it so that the background is always grabbed when redrawing takes place; so if the user has decided they want to use the `background` of the widget as the canvas background, simply styling the background a new colour will result in the canvas updating.

Also document `clear_pixel` and `clear_pixels`.