### PR TITLE
Fix typo on error message

### DIFF
--- a/src/textual_canvas/canvas.py
+++ b/src/textual_canvas/canvas.py
@@ -167,7 +167,7 @@ class Canvas(ScrollView, can_focus=True):
         """
         if self._outwith_the_canvas(x, y):
             raise CanvasError(
-                f"x={x}, x={y} is not within 0, 0, {self._width}, {self._height}"
+                f"x={x}, y={y} is not within 0, 0, {self._width}, {self._height}"
             )
 
     def clear(


### PR DESCRIPTION
Hi! I was playing a bit with `textual-canvas` when I noticed a small typo in the error raised from `_pixel_check`.