### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/code-checks.yaml
+++ b/.github/workflows/code-checks.yaml
@@ -1,5 +1,8 @@
 name: Code quality checks
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/davep/textual-canvas/security/code-scanning/1](https://github.com/davep/textual-canvas/security/code-scanning/1)

In general, the fix is to explicitly set `permissions` for the workflow or specific jobs so that the `GITHUB_TOKEN` has only the minimal scopes required. For a code-quality job that only checks out and reads the code, `contents: read` is typically sufficient; no write permissions are needed.

The best fix here without changing existing functionality is to add a workflow-level `permissions` block after the `name:` declaration (before `on:`) in `.github/workflows/code-checks.yaml`, setting `contents: read`. This applies to all jobs (currently just `quality-checks`) and documents the intended access level. No imports or additional methods are needed because this is configuration-only. If future steps require more permissions, they can override or extend this at the job level.

Concretely, update `.github/workflows/code-checks.yaml` to insert:

```yaml
permissions:
  contents: read
```

after line 1 (`name: Code quality checks`). No other lines need to change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
